### PR TITLE
[FIX INFRA-1028] Add support for warnings to plugin info

### DIFF
--- a/src/main/java/org/jenkinsci/confluence/plugins/JenkinsPluginInfoMacro.java
+++ b/src/main/java/org/jenkinsci/confluence/plugins/JenkinsPluginInfoMacro.java
@@ -279,11 +279,19 @@ public class JenkinsPluginInfoMacro extends BaseMacro {
 
             if (!currentWarnings.isEmpty()) {
                 // there are warnings
-                toBeRendered.append("{warning}This plugin may not be safe to use. Please review the following warnings before use:");
+                toBeRendered.append("{warning}The current version of this plugin may not be safe to use. Please review the following warnings before use:\n\n");
                 for (JSONObject warning : currentWarnings) {
-                    toBeRendered.append(String.format("* [%s|%s]", warning.get("message"), warning.get("url")));
+                    toBeRendered.append(String.format("* [%s|%s]\n", warning.get("message"), warning.get("url")));
                 }
-                toBeRendered.append("{warning}");
+                toBeRendered.append("\n{warning}\n\n");
+            }
+
+            if (!pluginWarnings.isEmpty()) {
+                toBeRendered.append("{info}Older versions of this plugin may not be safe to use. Please review the following warnings before using an older version:\n\n");
+                for (JSONObject warning : pluginWarnings) {
+                    toBeRendered.append(String.format("* [%s|%s]\n", warning.get("message"), warning.get("url")));
+                }
+                toBeRendered.append("\n{info}\n\n");
             }
 
             if (renderContext instanceof PageContext) {


### PR DESCRIPTION
Untested.

Some weirdness in the case of plugins that are not currently published at all but had some releases in the past that were safe (i.e. no "all versions" warning). I doubt that's a particularly relevant case though.

For format see https://github.com/jenkinsci/backend-update-center2/pull/96 (which this depends on, do not merge before that).