### PR TITLE
Switch to HTTPs now that Confluence is on JRE8

### DIFF
--- a/src/main/java/org/jenkinsci/confluence/plugins/JenkinsRetriever.java
+++ b/src/main/java/org/jenkinsci/confluence/plugins/JenkinsRetriever.java
@@ -17,7 +17,7 @@ public class JenkinsRetriever {
 			HttpRetrievalService httpRetrievalService) throws IOException,
 			PluginHttpException, ParseException {
 		HttpResponse response = httpRetrievalService
-				.get("http://updates.jenkins-ci.org/update-center.json");
+				.get("https://updates.jenkins.io/update-center.json");
 		if (response.getStatusCode() != 200) {
 			throw new PluginHttpException(response.getStatusCode());
 		}


### PR DESCRIPTION
With jenkins-infra/confluence#6 we upgraded to OpenJDK8 in the container, which has since been deployed into production.

Fixes INFRA-1025